### PR TITLE
Add date clearing functionality to date picker

### DIFF
--- a/app/notes/page.js
+++ b/app/notes/page.js
@@ -307,9 +307,16 @@ export default function NotesPage() {
               </Button>
               <CustomDatePicker
                 value={dateFilter ? new Date(dateFilter) : null}
-                onChange={(selectedDate) => setDateFilter(selectedDate.toISOString().split('T')[0])}
+                onChange={(selectedDate) => {
+                  if (selectedDate) {
+                    setDateFilter(selectedDate.toISOString().split('T')[0])
+                  } else {
+                    setDateFilter('')  // Clear the date filter when null is passed
+                  }
+                }}
                 name="mainDate"
                 placeholder="Select date"
+                allowClear={true}
               />
               <Button
                 variant="ghost"

--- a/app/test-datepicker/page.js
+++ b/app/test-datepicker/page.js
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import CustomDatePicker from '@/components/CustomDatePicker'
+
+export default function TestDatePicker() {
+  const [dateValue, setDateValue] = useState(null)
+  
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Test Date Picker</h1>
+      
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-2">
+            Date Picker with Clear Button:
+          </label>
+          <CustomDatePicker
+            value={dateValue}
+            onChange={(date) => {
+              console.log('Date changed to:', date)
+              setDateValue(date)
+            }}
+            placeholder="Select a date"
+            allowClear={true}
+          />
+        </div>
+        
+        <div className="mt-4 p-4 bg-gray-100 rounded">
+          <p className="text-sm">
+            <strong>Current Value:</strong> {dateValue ? dateValue.toISOString() : 'null'}
+          </p>
+        </div>
+        
+        <div className="mt-4">
+          <button
+            onClick={() => setDateValue(new Date())}
+            className="px-4 py-2 bg-blue-500 text-white rounded mr-2"
+          >
+            Set Today
+          </button>
+          <button
+            onClick={() => setDateValue(null)}
+            className="px-4 py-2 bg-gray-500 text-white rounded"
+          >
+            Clear Programmatically
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/CustomDatePicker.jsx
+++ b/components/CustomDatePicker.jsx
@@ -18,6 +18,7 @@ export default function CustomDatePicker({
   allowClear = false,
   ...props
 }) {
+  console.log('CustomDatePicker rendered with allowClear:', allowClear, 'value:', value)
   const [isOpen, setIsOpen] = useState(false)
   const [currentMonth, setCurrentMonth] = useState(() => {
     try {
@@ -77,16 +78,14 @@ export default function CustomDatePicker({
         setCurrentMonth(date)
         setSelectedDate(date)
       } else {
-        // If invalid date, use current date
-        const now = new Date()
-        setCurrentMonth(now)
-        setSelectedDate(now)
+        // If invalid date, clear the selected date
+        setSelectedDate(null)
       }
     } else {
-      // No value provided, use current date
+      // No value provided, clear selected date but keep current month for calendar navigation
       const now = new Date()
       setCurrentMonth(now)
-      setSelectedDate(now)
+      setSelectedDate(null)
     }
   }, [value])
 
@@ -121,9 +120,12 @@ export default function CustomDatePicker({
   }
 
   const handleClearDate = (e) => {
+    console.log('Clear button clicked!')
+    e.preventDefault()
     e.stopPropagation()
     setSelectedDate(null)
     onChange(null)
+    setIsOpen(false) // Close the calendar if it's open
   }
 
   const calculatePopupPosition = () => {
@@ -298,7 +300,7 @@ export default function CustomDatePicker({
       )}
 
       {/* Date Display Button */}
-      <div className="relative">
+      <div className="relative flex items-center">
         <button
           ref={buttonRef}
           type="button"
@@ -312,7 +314,7 @@ export default function CustomDatePicker({
           }}
           disabled={disabled}
           className={`
-              w-full h-[42px] px-6 ${allowClear && selectedDate ? 'pr-12' : 'pr-6'} bg-gradient-to-r from-slate-100 to-blue-100 rounded-xl text-lg font-semibold text-slate-900 font-display border border-slate-200 cursor-pointer hover:from-slate-200 hover:to-blue-200 transition-all duration-200 shadow-sm text-left flex items-center
+              flex-1 h-[42px] pl-6 ${allowClear && selectedDate ? 'pr-14' : 'pr-6'} bg-gradient-to-r from-slate-100 to-blue-100 rounded-xl text-lg font-semibold text-slate-900 font-display border border-slate-200 cursor-pointer hover:from-slate-200 hover:to-blue-200 transition-all duration-200 shadow-sm text-left flex items-center
               ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
             `}
           aria-label={label || 'Select date'}
@@ -328,10 +330,11 @@ export default function CustomDatePicker({
           <button
             type="button"
             onClick={handleClearDate}
-            className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1.5 rounded-lg hover:bg-slate-200/50 transition-colors duration-200"
+            onMouseDown={(e) => e.preventDefault()} // Prevent focus from moving
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1.5 rounded-lg bg-white hover:bg-red-50 transition-colors duration-200 z-20 border border-slate-200"
             aria-label="Clear date"
           >
-            <X size={18} className="text-slate-500 hover:text-slate-700" />
+            <X size={18} className="text-slate-600 hover:text-red-600" />
           </button>
         )}
 

--- a/components/CustomDatePicker.jsx
+++ b/components/CustomDatePicker.jsx
@@ -15,6 +15,7 @@ export default function CustomDatePicker({
   required = false,
   minDate,
   maxDate,
+  allowClear = false,
   ...props
 }) {
   const [isOpen, setIsOpen] = useState(false)
@@ -117,6 +118,12 @@ export default function CustomDatePicker({
     setSelectedDate(localDate)
     onChange(localDate)
     setIsOpen(false)
+  }
+
+  const handleClearDate = (e) => {
+    e.stopPropagation()
+    setSelectedDate(null)
+    onChange(null)
   }
 
   const calculatePopupPosition = () => {
@@ -305,16 +312,28 @@ export default function CustomDatePicker({
           }}
           disabled={disabled}
           className={`
-              w-full h-[42px] px-6 bg-gradient-to-r from-slate-100 to-blue-100 rounded-xl text-lg font-semibold text-slate-900 font-display border border-slate-200 cursor-pointer hover:from-slate-200 hover:to-blue-200 transition-all duration-200 shadow-sm text-left
+              w-full h-[42px] px-6 ${allowClear && selectedDate ? 'pr-12' : 'pr-6'} bg-gradient-to-r from-slate-100 to-blue-100 rounded-xl text-lg font-semibold text-slate-900 font-display border border-slate-200 cursor-pointer hover:from-slate-200 hover:to-blue-200 transition-all duration-200 shadow-sm text-left flex items-center
               ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
             `}
           aria-label={label || 'Select date'}
           aria-haspopup="true"
           aria-expanded={isOpen}
         >
-          <Calendar size={20} className="inline mr-3 text-blue-600" />
-          {formatDisplayDate(selectedDate)}
+          <Calendar size={20} className="mr-3 text-blue-600 flex-shrink-0" />
+          <span className="flex-1">{formatDisplayDate(selectedDate)}</span>
         </button>
+        
+        {/* Clear Button */}
+        {allowClear && selectedDate && !disabled && (
+          <button
+            type="button"
+            onClick={handleClearDate}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1.5 rounded-lg hover:bg-slate-200/50 transition-colors duration-200"
+            aria-label="Clear date"
+          >
+            <X size={18} className="text-slate-500 hover:text-slate-700" />
+          </button>
+        )}
 
         {/* Calendar Dropdown */}
         {isOpen && (


### PR DESCRIPTION
Add clear date functionality to the `CustomDatePicker` to allow users to remove date filters and view all notes.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e305c90-47e1-434b-af1a-805f07cc962c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e305c90-47e1-434b-af1a-805f07cc962c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

